### PR TITLE
Add Rollup ILM Action to Cold Phase

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupAction.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link LifecycleAction} which sets the index's priority. The higher the priority, the faster the recovery.
+ */
+public class RollupAction implements LifecycleAction {
+    public static final String NAME = "rollup";
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<RollupAction, Void> PARSER = new ConstructingObjectParser<>(NAME,
+        a -> new RollupAction((RollupV2Config) a[0]));
+
+    //package private for testing
+    final RollupV2Config config;
+
+    static {
+        PARSER.declareField(ConstructingObjectParser.constructorArg(),
+            (p, c) -> RollupV2Config.fromXContent(p, "_source_index_todo"),
+            new ParseField("config"), ObjectParser.ValueType.OBJECT);
+    }
+
+    public static RollupAction parse(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    public RollupAction(RollupV2Config config) {
+        this.config = config;
+    }
+
+    public RollupAction(StreamInput in) throws IOException {
+        this(new RollupV2Config(in));
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("config", config);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        config.writeTo(out);
+    }
+
+    @Override
+    public boolean isSafeAction() {
+        return false;
+    }
+
+    @Override
+    public List<Step> toSteps(Client client, String phase, StepKey nextStepKey) {
+        StepKey checkNotWriteIndex = new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME);
+        StepKey readOnlyKey = new StepKey(phase, NAME, ReadOnlyAction.NAME);
+        StepKey rollupKey = new StepKey(phase, NAME, NAME);
+        CheckNotDataStreamWriteIndexStep checkNotWriteIndexStep = new CheckNotDataStreamWriteIndexStep(checkNotWriteIndex,
+            readOnlyKey);
+        Settings readOnlySettings = Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build();
+        UpdateSettingsStep readOnlyStep = new UpdateSettingsStep(readOnlyKey, nextStepKey, client, readOnlySettings);
+        RollupStep rollupStep = new RollupStep(rollupKey, nextStepKey, client, config);
+        return List.of(checkNotWriteIndexStep, readOnlyStep, rollupStep);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RollupAction that = (RollupAction) o;
+
+        return Objects.equals(this.config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(config);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupStep.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateObserver;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Action;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+
+import java.util.Objects;
+
+/**
+ * Rolls up index using a {@link RollupV2Config}
+ */
+public class RollupStep extends AsyncActionStep {
+    public static final String NAME = "rollup";
+
+    private final RollupV2Config config;
+
+    public RollupStep(StepKey key, StepKey nextStepKey, Client client, RollupV2Config config) {
+        super(key, nextStepKey, client);
+        this.config = config;
+    }
+
+    @Override
+    public boolean isRetryable() {
+        return false;
+    }
+
+    @Override
+    public void performAction(IndexMetadata indexMetadata, ClusterState currentState, ClusterStateObserver observer, Listener listener) {
+        config.setSourceIndex(indexMetadata.getIndex().getName());
+        RollupV2Action.Request request = new RollupV2Action.Request(config);
+        getClient().execute(RollupV2Action.INSTANCE, request,
+                ActionListener.wrap(response -> listener.onResponse(true), listener::onFailure));
+    }
+
+    public RollupV2Config getConfig() {
+        return config;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), config);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        RollupStep other = (RollupStep) obj;
+        return super.equals(obj) &&
+                Objects.equals(config, other.config);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -42,7 +42,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
     static final List<String> ORDERED_VALID_WARM_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, ReadOnlyAction.NAME,
         AllocateAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME);
     static final List<String> ORDERED_VALID_COLD_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, AllocateAction.NAME,
-        FreezeAction.NAME, SearchableSnapshotAction.NAME);
+        FreezeAction.NAME, SearchableSnapshotAction.NAME, RollupAction.NAME);
     static final List<String> ORDERED_VALID_FROZEN_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, AllocateAction.NAME,
         FreezeAction.NAME, SearchableSnapshotAction.NAME);
     static final List<String> ORDERED_VALID_DELETE_ACTIONS = Arrays.asList(WaitForSnapshotAction.NAME, DeleteAction.NAME);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
@@ -45,11 +45,11 @@ public class RollupV2Config implements NamedWriteable, ToXContentObject {
     private static final String TIMEOUT = "timeout";
     private static final String ROLLUP_INDEX = "rollup_index";
 
-    private final String sourceIndex;
     private final String rollupIndex;
     private final GroupConfig groupConfig;
     private final List<MetricConfig> metricsConfig;
     private final TimeValue timeout;
+    private String sourceIndex;
 
     private static final ConstructingObjectParser<RollupV2Config, String> PARSER;
     static {
@@ -100,6 +100,10 @@ public class RollupV2Config implements NamedWriteable, ToXContentObject {
 
     public String getSourceIndex() {
         return sourceIndex;
+    }
+
+    public void setSourceIndex(String sourceIndex) {
+        this.sourceIndex = sourceIndex;
     }
 
     public GroupConfig getGroupConfig() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
@@ -57,7 +57,8 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, FreezeAction.NAME, FreezeAction::new),
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, SetPriorityAction.NAME, SetPriorityAction::new),
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, UnfollowAction.NAME, UnfollowAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new)
+                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new),
+                new NamedWriteableRegistry.Entry(LifecycleAction.class, RollupAction.NAME, RollupAction::new)
             ));
     }
 
@@ -79,7 +80,9 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SetPriorityAction.NAME), SetPriorityAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SearchableSnapshotAction.NAME),
-                SearchableSnapshotAction::parse)
+                SearchableSnapshotAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RollupAction.NAME), RollupAction::parse)
+
         ));
         return new NamedXContentRegistry(entries);
     }
@@ -136,6 +139,8 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
                     return new UnfollowAction();
                 case SearchableSnapshotAction.NAME:
                     return new SearchableSnapshotAction(randomAlphaOfLengthBetween(1, 10));
+                case RollupAction.NAME:
+                    return RollupActionTests.randomInstance();
                 default:
                     throw new IllegalArgumentException("invalid action [" + action + "]");
             }};
@@ -194,6 +199,8 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
                     return new UnfollowAction();
                 case SearchableSnapshotAction.NAME:
                     return new SearchableSnapshotAction(randomAlphaOfLengthBetween(1, 10));
+                case RollupAction.NAME:
+                    return RollupActionTests.randomInstance();
                 default:
                     throw new IllegalArgumentException("invalid action [" + action + "]");
             }};

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupActionTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2ConfigTests;
+
+import java.util.List;
+
+public class RollupActionTests extends AbstractActionTestCase<RollupAction> {
+
+    static RollupAction randomInstance() {
+        return new RollupAction(RollupV2ConfigTests.randomConfig(random()));
+    }
+
+    @Override
+    protected RollupAction doParseInstance(XContentParser parser) {
+        return RollupAction.parse(parser);
+    }
+
+    @Override
+    protected RollupAction createTestInstance() {
+        return randomInstance();
+    }
+
+    @Override
+    protected Reader<RollupAction> instanceReader() {
+        return RollupAction::new;
+    }
+
+    @Override
+    public boolean isSafeAction() {
+        return false;
+    }
+
+    public void testToSteps() {
+        RollupAction action = createTestInstance();
+        String phase = randomAlphaOfLengthBetween(1, 10);
+        StepKey nextStepKey = new StepKey(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10),
+            randomAlphaOfLengthBetween(1, 10));
+        List<Step> steps = action.toSteps(null, phase, nextStepKey);
+        assertNotNull(steps);
+        assertEquals(3, steps.size());
+    }
+
+    public void testEqualsAndHashCode() {
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copy, this::notCopy);
+    }
+
+    RollupAction copy(RollupAction rollupAction) {
+        return new RollupAction(rollupAction.config);
+    }
+
+    RollupAction notCopy(RollupAction rollupAction) {
+        RollupV2Config newConfig = new RollupV2Config(rollupAction.config.getSourceIndex() + "not",
+            rollupAction.config.getGroupConfig(), rollupAction.config.getMetricsConfig(), rollupAction.config.getTimeout(),
+            rollupAction.config.getRollupIndex());
+        return new RollupAction(newConfig);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -7,7 +7,12 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.rollup.job.DateHistogramGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2ConfigTests;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,6 +53,9 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
     private static final SetPriorityAction TEST_PRIORITY_ACTION = new SetPriorityAction(0);
     private static final UnfollowAction TEST_UNFOLLOW_ACTION  = new UnfollowAction();
     private static final SearchableSnapshotAction TEST_SEARCHABLE_SNAPSHOT_ACTION = new SearchableSnapshotAction("repo");
+    private static final RollupAction TEST_ROLLUP_ACTION =new RollupAction(new RollupV2Config("source",
+        new GroupConfig(new DateHistogramGroupConfig.FixedInterval("field", DateHistogramInterval.DAY)),
+        Collections.emptyList(), null, "rollup"));
 
     public void testValidatePhases() {
         boolean invalid = randomBoolean();
@@ -698,6 +706,8 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
                 return TEST_UNFOLLOW_ACTION;
             case SearchableSnapshotAction.NAME:
                 return TEST_SEARCHABLE_SNAPSHOT_ACTION;
+            case RollupAction.NAME:
+                return TEST_ROLLUP_ACTION;
             default:
                 throw new IllegalArgumentException("unsupported timeseries phase action [" + actionName + "]");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2ConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2ConfigTests.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Random;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.equalTo;
@@ -32,10 +33,15 @@ public class RollupV2ConfigTests extends AbstractSerializingTestCase<RollupV2Con
 
     @Override
     protected RollupV2Config createTestInstance() {
+        return randomConfig(random());
+    }
+
+    public static RollupV2Config randomConfig(Random random) {
+        final String sourceIndex = randomAlphaOfLength(10);
         final String rollupIndex = "rollup-" + sourceIndex;
-        final TimeValue timeout = randomBoolean() ? null : ConfigTestHelpers.randomTimeout(random());
-        final GroupConfig groupConfig = ConfigTestHelpers.randomGroupConfig(random());
-        final List<MetricConfig> metricConfigs = ConfigTestHelpers.randomMetricsConfigs(random());
+        final TimeValue timeout = random.nextBoolean() ? null : ConfigTestHelpers.randomTimeout(random);
+        final GroupConfig groupConfig = ConfigTestHelpers.randomGroupConfig(random);
+        final List<MetricConfig> metricConfigs = ConfigTestHelpers.randomMetricsConfigs(random);
         return new RollupV2Config(sourceIndex, groupConfig, metricConfigs, timeout, rollupIndex);
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.LifecycleType;
 import org.elasticsearch.xpack.core.ilm.ReadOnlyAction;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.RollupAction;
 import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
@@ -232,7 +233,8 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(WaitForSnapshotAction.NAME),
                 WaitForSnapshotAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SearchableSnapshotAction.NAME),
-                SearchableSnapshotAction::parse)
+                SearchableSnapshotAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RollupAction.NAME), RollupAction::parse)
         );
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.core.ilm.OperationMode;
 import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.ReadOnlyAction;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.RollupAction;
 import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
@@ -92,7 +93,8 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, FreezeAction.NAME, FreezeAction::new),
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, SetPriorityAction.NAME, SetPriorityAction::new),
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, UnfollowAction.NAME, UnfollowAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new)
+                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new),
+                new NamedWriteableRegistry.Entry(LifecycleAction.class, RollupAction.NAME, RollupAction::new)
             ));
     }
 
@@ -114,7 +116,8 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SetPriorityAction.NAME), SetPriorityAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SearchableSnapshotAction.NAME),
-                SearchableSnapshotAction::parse)
+                SearchableSnapshotAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RollupAction.NAME), RollupAction::parse)
         ));
         return new NamedXContentRegistry(entries);
     }


### PR DESCRIPTION
This commit introduces a new ILM action that
executes the Rollup config against the index